### PR TITLE
Allow build even with missing clientId

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -237,7 +237,12 @@ android.applicationVariants.configureEach {
 }
 
 fun getLocalProperty(name: String): String {
-    return getProperty("$projectDir/local.properties", name)
+    val localPropertiesFile = file("$projectDir/local.properties")
+    return if (localPropertiesFile.exists()) {
+        getProperty("$projectDir/local.properties", name)
+    } else {
+        System.getenv(name) ?: ""
+    }
 }
 
 fun getProperty(filename: String, name: String): String {


### PR DESCRIPTION
Potential change to allow the build to run even with no local.properties file. Checks in other PRs are failing because of the missing file.