### PR TITLE
Fix ToC formatting in documentation files.

### DIFF
--- a/docs/open-api.md
+++ b/docs/open-api.md
@@ -10,7 +10,7 @@ order: 40
 {:.no_toc}
 
 - ToC
-  {:toc}
+{:toc}
 
 ## Overview
 

--- a/docs/use-of-ai.md
+++ b/docs/use-of-ai.md
@@ -10,7 +10,7 @@ order: 30
 {:.no_toc}
 
 - ToC
-  {:toc}
+{:toc}
 
 ## Overview
 


### PR DESCRIPTION
Duplication in DDL appears to have been a caching issue, as there was no duplication found in the ddl-server.sql file or the data-model.md files.