### PR TITLE
added @JsonIgnore to the issueReports lazily loaded field of UserProfile

### DIFF
--- a/server/src/main/java/edu/cnm/deepdive/seesomethingabq/model/entity/UserProfile.java
+++ b/server/src/main/java/edu/cnm/deepdive/seesomethingabq/model/entity/UserProfile.java
@@ -85,6 +85,7 @@ public class UserProfile {
   // used AI to help with OneToMany annotation
   @OneToMany(mappedBy = "userProfile", fetch = FetchType.LAZY)
   @OrderBy("timeLastModified DESC")
+  @JsonIgnore
   private final List<IssueReport> issueReports = new LinkedList<>();
 
   public Long getId() {


### PR DESCRIPTION
This fixes the bug since it was just trying to grab that to serialize it. But we don't want it serialzed, ever. and if we want to lazily load it from that function later, we can cross that bridge later. We'd need to just grab the externalId (external key UUID) and re-fetch the user from it so it has a session or whatever it's called.