### PR TITLE
Update issue report list data

### DIFF
--- a/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/CreateIssueReportFragment.java
+++ b/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/CreateIssueReportFragment.java
@@ -99,7 +99,6 @@ public class CreateIssueReportFragment extends Fragment {
   private static final String TAG = CreateIssueReportFragment.class.getSimpleName();
   private static final int SEARCH_DEBOUNCE_MS = 500;
   private static final int MIN_QUERY_LENGTH = 3;
-  private static final String USER_REPORTS_REFRESH_REQUIRED = "user_reports_refresh_required";
 
   private FragmentCreateIssueReportBinding binding;
   private IssueTypeViewModel issueTypeViewModel;
@@ -650,7 +649,8 @@ public class CreateIssueReportFragment extends Fragment {
       NavController navController = Navigation.findNavController(binding.getRoot());
       NavBackStackEntry previousEntry = navController.getPreviousBackStackEntry();
       if (previousEntry != null) {
-        previousEntry.getSavedStateHandle().set(USER_REPORTS_REFRESH_REQUIRED, true);
+        previousEntry.getSavedStateHandle()
+            .set(UserDashboardRefresh.USER_REPORTS_REFRESH_REQUIRED, true);
       }
       navController.popBackStack();
     }

--- a/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/CreateIssueReportFragment.java
+++ b/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/CreateIssueReportFragment.java
@@ -46,6 +46,7 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
+import androidx.navigation.NavBackStackEntry;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import com.bumptech.glide.Glide;
 import com.google.android.gms.location.CurrentLocationRequest;
@@ -98,6 +99,7 @@ public class CreateIssueReportFragment extends Fragment {
   private static final String TAG = CreateIssueReportFragment.class.getSimpleName();
   private static final int SEARCH_DEBOUNCE_MS = 500;
   private static final int MIN_QUERY_LENGTH = 3;
+  private static final String USER_REPORTS_REFRESH_REQUIRED = "user_reports_refresh_required";
 
   private FragmentCreateIssueReportBinding binding;
   private IssueTypeViewModel issueTypeViewModel;
@@ -148,7 +150,7 @@ public class CreateIssueReportFragment extends Fragment {
     binding.backToDashboardButton.setOnClickListener((v) -> {
       clearPendingAttachments();
       NavController navController = Navigation.findNavController(v);
-      navController.navigate(R.id.navigate_to_user_dashboard_fragment);
+      navController.popBackStack();
     });
 
     binding.useCurrentLocationButton.setOnClickListener((v) -> requestCurrentLocation());
@@ -646,7 +648,11 @@ public class CreateIssueReportFragment extends Fragment {
       reportSubmitted = true;
       clearPendingAttachments();
       NavController navController = Navigation.findNavController(binding.getRoot());
-      navController.navigate(R.id.navigate_to_user_dashboard_fragment);
+      NavBackStackEntry previousEntry = navController.getPreviousBackStackEntry();
+      if (previousEntry != null) {
+        previousEntry.getSavedStateHandle().set(USER_REPORTS_REFRESH_REQUIRED, true);
+      }
+      navController.popBackStack();
     }
   }
 

--- a/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/ReportDetailFragment.kt
+++ b/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/ReportDetailFragment.kt
@@ -166,6 +166,7 @@ class ReportDetailFragment : Fragment() {
                     Snackbar.make(binding.root, "Saved", Snackbar.LENGTH_SHORT).show()
                     findNavController().previousBackStackEntry?.savedStateHandle
                         ?.set(UserDashboardRefresh.USER_REPORTS_REFRESH_REQUIRED, true)
+                    findNavController().popBackStack()
                 }
             }
             .exceptionally { thrown ->

--- a/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/ReportDetailFragment.kt
+++ b/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/ReportDetailFragment.kt
@@ -23,10 +23,6 @@ import com.google.android.material.chip.ChipDrawable
 @AndroidEntryPoint
 class ReportDetailFragment : Fragment() {
 
-    companion object {
-        private const val USER_REPORTS_REFRESH_REQUIRED = "user_reports_refresh_required"
-    }
-
     private var _binding: FragmentReportDetailBinding? = null
     private val binding: FragmentReportDetailBinding
         get() = _binding!!
@@ -169,7 +165,7 @@ class ReportDetailFragment : Fragment() {
                     setEditing(false)
                     Snackbar.make(binding.root, "Saved", Snackbar.LENGTH_SHORT).show()
                     findNavController().previousBackStackEntry?.savedStateHandle
-                        ?.set(USER_REPORTS_REFRESH_REQUIRED, true)
+                        ?.set(UserDashboardRefresh.USER_REPORTS_REFRESH_REQUIRED, true)
                 }
             }
             .exceptionally { thrown ->

--- a/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/ReportDetailFragment.kt
+++ b/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/ReportDetailFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -21,6 +22,10 @@ import com.google.android.material.chip.ChipDrawable
 
 @AndroidEntryPoint
 class ReportDetailFragment : Fragment() {
+
+    companion object {
+        private const val USER_REPORTS_REFRESH_REQUIRED = "user_reports_refresh_required"
+    }
 
     private var _binding: FragmentReportDetailBinding? = null
     private val binding: FragmentReportDetailBinding
@@ -163,6 +168,8 @@ class ReportDetailFragment : Fragment() {
                     populateIssueTypeChips()
                     setEditing(false)
                     Snackbar.make(binding.root, "Saved", Snackbar.LENGTH_SHORT).show()
+                    findNavController().previousBackStackEntry?.savedStateHandle
+                        ?.set(USER_REPORTS_REFRESH_REQUIRED, true)
                 }
             }
             .exceptionally { thrown ->

--- a/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/UserDashboardFragment.java
+++ b/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/UserDashboardFragment.java
@@ -40,8 +40,6 @@ import kotlin.Unit;
  */
 public class UserDashboardFragment extends Fragment {
 
-  private static final String USER_REPORTS_REFRESH_REQUIRED = "user_reports_refresh_required";
-
   private FragmentUserDashboardBinding binding;
   private UserViewModel userViewModel;
   private IssueReportViewModel issueReportViewModel;
@@ -91,11 +89,12 @@ public class UserDashboardFragment extends Fragment {
     NavBackStackEntry currentEntry = navController.getCurrentBackStackEntry();
     if (currentEntry != null) {
       currentEntry.getSavedStateHandle()
-          .<Boolean>getLiveData(USER_REPORTS_REFRESH_REQUIRED, false)
+          .<Boolean>getLiveData(UserDashboardRefresh.USER_REPORTS_REFRESH_REQUIRED, false)
           .observe(getViewLifecycleOwner(), refreshRequired -> {
             if (Boolean.TRUE.equals(refreshRequired)) {
-              currentEntry.getSavedStateHandle().set(USER_REPORTS_REFRESH_REQUIRED, false);
-              adapter.refresh();
+              currentEntry.getSavedStateHandle()
+                  .set(UserDashboardRefresh.USER_REPORTS_REFRESH_REQUIRED, false);
+              refreshMyReports();
             }
           });
     }
@@ -107,6 +106,12 @@ public class UserDashboardFragment extends Fragment {
             pagingData ->
                 adapter.submitData(getViewLifecycleOwner().getLifecycle(), pagingData)
         );
+  }
+
+  private void refreshMyReports() {
+    if (adapter != null) {
+      adapter.refresh();
+    }
   }
 
   @Override

--- a/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/UserDashboardFragment.java
+++ b/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/UserDashboardFragment.java
@@ -23,6 +23,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.NavBackStackEntry;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import dagger.hilt.android.AndroidEntryPoint;
@@ -38,6 +39,8 @@ import kotlin.Unit;
  * Fragment showing the signed-in user's dashboard and navigation to report creation.
  */
 public class UserDashboardFragment extends Fragment {
+
+  private static final String USER_REPORTS_REFRESH_REQUIRED = "user_reports_refresh_required";
 
   private FragmentUserDashboardBinding binding;
   private UserViewModel userViewModel;
@@ -83,6 +86,20 @@ public class UserDashboardFragment extends Fragment {
       return Unit.INSTANCE;
     });
     binding.issueReportsRecycler.setAdapter(adapter);
+
+    NavController navController = Navigation.findNavController(view);
+    NavBackStackEntry currentEntry = navController.getCurrentBackStackEntry();
+    if (currentEntry != null) {
+      currentEntry.getSavedStateHandle()
+          .<Boolean>getLiveData(USER_REPORTS_REFRESH_REQUIRED, false)
+          .observe(getViewLifecycleOwner(), refreshRequired -> {
+            if (Boolean.TRUE.equals(refreshRequired)) {
+              currentEntry.getSavedStateHandle().set(USER_REPORTS_REFRESH_REQUIRED, false);
+              adapter.refresh();
+            }
+          });
+    }
+
     issueReportViewModel
         .getMyIssueReports(requireActivity())
         .observe(

--- a/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/UserDashboardRefresh.kt
+++ b/app/src/main/java/edu/cnm/deepdive/seesomethingabq/controller/UserDashboardRefresh.kt
@@ -1,0 +1,14 @@
+package edu.cnm.deepdive.seesomethingabq.controller
+
+/**
+ * Keys used for navigation-result style refresh triggers back to [UserDashboardFragment].
+ *
+ * This mirrors the manager-side pattern (SavedStateHandle boolean flag) while keeping the
+ * mechanism local to the user dashboard report list flow.
+ */
+object UserDashboardRefresh {
+
+  const val USER_REPORTS_REFRESH_REQUIRED: String = "user_reports_refresh_required"
+
+}
+


### PR DESCRIPTION
makes user dashboard issue report list update when a report is created or edited

test instructions:
- launch app in user mode
- create a report
- confirm the new report is shown in the issue report list on the dashboard immediately after being created
- edit a report
- go back to the list page
- confirm the updated data for the edited report is shown in the list immediately after being edited