### PR TITLE
Change by Codex: Remove duplicate in-content report title

### DIFF
--- a/app/src/main/res/layout/fragment_manager_report_detail.xml
+++ b/app/src/main/res/layout/fragment_manager_report_detail.xml
@@ -28,14 +28,6 @@
     android:orientation="vertical"
     android:padding="@dimen/full_dynamic_spacing">
 
-    <TextView
-      android:id="@+id/form_title"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="@dimen/full_dynamic_spacing"
-      android:text="Report Details"
-      android:textAppearance="?attr/textAppearanceHeadlineSmall"/>
-
     <com.google.android.material.textfield.TextInputLayout
       android:id="@+id/description_layout"
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_report_detail.xml
+++ b/app/src/main/res/layout/fragment_report_detail.xml
@@ -28,16 +28,6 @@
     android:orientation="vertical"
     android:padding="@dimen/full_dynamic_spacing">
 
-    <!-- Header -->
-
-    <TextView
-      android:id="@+id/form_title"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:text="Report Details"
-      android:textAppearance="?attr/textAppearanceHeadlineSmall"
-      android:layout_marginBottom="@dimen/full_dynamic_spacing"/>
-
     <!-- Description -->
 
     <com.google.android.material.textfield.TextInputLayout


### PR DESCRIPTION
Removed the redundant in-content "Report Details" header from the user and manager report detail layouts so the toolbar title remains the single screen title.